### PR TITLE
Add clang-format configuration and formatting workflow

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,17 @@
+BasedOnStyle: LLVM
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+ColumnLimit: 100
+BreakBeforeBraces: Allman
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AlignAfterOpenBracket: Align
+AlignOperands: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignTrailingComments: true
+SortIncludes: false
+SpaceBeforeParens: ControlStatements
+PointerAlignment: Left

--- a/Makefile
+++ b/Makefile
@@ -78,9 +78,28 @@ toml.o: toml.c toml.h
 debug.o: debug.c debug.h
 	$(CC) $(CFLAGS) -c $<
 
-format:
+# Check if clang-format is available
+CLANG_FORMAT := $(shell command -v clang-format 2> /dev/null)
+
+format-deps:
+	@if [ -z "$(CLANG_FORMAT)" ]; then \
+		if command -v brew >/dev/null 2>&1; then \
+			echo "Installing clang-format via Homebrew..."; \
+			brew install clang-format; \
+		else \
+			echo "Error: clang-format not found and no package manager available."; \
+			echo "Please install clang-format manually:"; \
+			echo "  macOS: brew install clang-format"; \
+			echo "  Ubuntu: sudo apt-get install clang-format"; \
+			echo "  Fedora: sudo dnf install clang-tools-extra"; \
+			echo "  Arch: sudo pacman -S clang"; \
+			exit 1; \
+		fi \
+	fi
+
+format: format-deps
 	clang-format -i $(FORMAT_FILES)
-	
+
 # New target for release build
 release: $(OBJS)
 	@echo "Building release version ($(TARGET))..."

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,22 @@ RELEASE_CFLAGS = -std=c99 -Wall -Wextra -O2 -DNDEBUG # -O2 optimization, NDEBUG 
 TARGET = llm_ctx
 TEST_JS_PARSER = test_js_parser
 SRC = main.c gitignore.c arena.c tokenizer.c tokenizer_diagnostics.c config.c toml.c debug.c
+FORMAT_FILES = \
+        main.c \
+        gitignore.c \
+        arena.c \
+        tokenizer.c \
+        tokenizer_diagnostics.c \
+        config.c \
+        toml.c \
+        debug.c \
+        config.h \
+        debug.h \
+        tokenizer.h \
+        gitignore.h \
+        toml.h \
+        arena.h \
+        tokenizer/tiktoken.h
 TEST_SRC = tests/test_gitignore.c tests/test_cli.c tests/test_stdin.c
 TEST_TARGETS = tests/test_gitignore tests/test_cli tests/test_stdin tests/test_tree_flags tests/test_tokenizer tests/test_tokenizer_cli tests/test_arena tests/test_config tests/test_filerank tests/test_keywords tests/test_filerank_cutoff tests/test_cli_exclude
 PREFIX ?= /usr/local
@@ -61,6 +77,9 @@ toml.o: toml.c toml.h
 
 debug.o: debug.c debug.h
 	$(CC) $(CFLAGS) -c $<
+
+format:
+	clang-format -i $(FORMAT_FILES)
 	
 # New target for release build
 release: $(OBJS)

--- a/README.md
+++ b/README.md
@@ -136,6 +136,14 @@ repository root. Run the formatter before sending patches:
 make format
 ```
 
+**Prerequisites:**
+- **macOS:** `brew install clang-format` (or let `make format` install it automatically)
+- **Ubuntu/Debian:** `sudo apt-get install clang-format`
+- **Fedora:** `sudo dnf install clang-tools-extra`
+- **Arch Linux:** `sudo pacman -S clang`
+
+The `make format` target will automatically install clang-format if needed on macOS with Homebrew. On other platforms, please install clang-format manually before running the formatter.
+
 This target applies the preferred style to the primary C sources and headers so code stays aligned with
 the established baseline.
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,18 @@ Follow these steps to get the code, build it, and make it easily accessible:
     ```
     Now run: `llm_ctx --help`
 
+### Code Formatting
+
+Consistent formatting is enforced with `clang-format` using the configuration in `.clang-format` at the
+repository root. Run the formatter before sending patches:
+
+```bash
+make format
+```
+
+This target applies the preferred style to the primary C sources and headers so code stays aligned with
+the established baseline.
+
 ## Tutorials
 
 This section guides you through the basic usage of `llm_ctx`.

--- a/arena.h
+++ b/arena.h
@@ -9,52 +9,62 @@
 #include <stdlib.h>
 
 // Custom max_align_t for systems without it
-#if !defined(__STDC_VERSION_STDDEF_H__) && !defined(_MSC_VER) && !defined(_MAX_ALIGN_T_DEFINED) && !defined(__APPLE__)
-typedef union { long long i; long double d; void *p; } max_align_t;
+#if !defined(__STDC_VERSION_STDDEF_H__) && !defined(_MSC_VER) && !defined(_MAX_ALIGN_T_DEFINED) && \
+    !defined(__APPLE__)
+typedef union
+{
+    long long i;
+    long double d;
+    void* p;
+} max_align_t;
 #define _MAX_ALIGN_T_DEFINED
 #endif
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 #ifndef ARENA_API
 #define ARENA_API extern
 #endif
 
-typedef struct Arena {
-    unsigned char *base;
-    size_t pos;
-    size_t size;
+    typedef struct Arena
+    {
+        unsigned char* base;
+        size_t pos;
+        size_t size;
 #ifdef ARENA_ENABLE_COMMIT
-    size_t commit;
+        size_t commit;
 #endif
-} Arena;
+    } Arena;
 
 #define KiB(x) ((size_t)(x) << 10)
 #define MiB(x) ((size_t)(x) << 20)
 #define GiB(x) ((size_t)(x) << 30)
 
-ARENA_API size_t arena_align_forward(size_t p, size_t a);
+    ARENA_API size_t arena_align_forward(size_t p, size_t a);
 
-ARENA_API void arena_clear(Arena *a);
-ARENA_API void arena_destroy(Arena *a);
-ARENA_API Arena arena_create(size_t reserve);
-ARENA_API void *arena_push_size(Arena *a, size_t size, size_t align);
-ARENA_API size_t arena_get_mark(Arena *a);
-ARENA_API void arena_set_mark(Arena *a, size_t mark);
+    ARENA_API void arena_clear(Arena* a);
+    ARENA_API void arena_destroy(Arena* a);
+    ARENA_API Arena arena_create(size_t reserve);
+    ARENA_API void* arena_push_size(Arena* a, size_t size, size_t align);
+    ARENA_API size_t arena_get_mark(Arena* a);
+    ARENA_API void arena_set_mark(Arena* a, size_t mark);
 
-#define arena_push(arena,T) ((T*)arena_push_size((arena),sizeof(T),__alignof__(T)))
-#define arena_push_array(arena,T,count) ((T*)arena_push_size((arena),sizeof(T)*(count),__alignof__(T)))
+#define arena_push(arena, T) ((T*)arena_push_size((arena), sizeof(T), __alignof__(T)))
+#define arena_push_array(arena, T, count)                                                          \
+    ((T*)arena_push_size((arena), sizeof(T) * (count), __alignof__(T)))
 
 /* Safe versions that exit on failure */
-#define arena_push_safe(arena,T) ((T*)arena_push_size_safe((arena),sizeof(T),__alignof__(T)))
-#define arena_push_array_safe(arena,T,count) ((T*)arena_push_size_safe((arena),sizeof(T)*(count),__alignof__(T)))
+#define arena_push_safe(arena, T) ((T*)arena_push_size_safe((arena), sizeof(T), __alignof__(T)))
+#define arena_push_array_safe(arena, T, count)                                                     \
+    ((T*)arena_push_size_safe((arena), sizeof(T) * (count), __alignof__(T)))
 
-/* String duplication and error handling */
-ARENA_API char *arena_strdup(Arena *a, const char *s);
-ARENA_API char *arena_strdup_safe(Arena *a, const char *s);
-ARENA_API void *arena_push_size_safe(Arena *a, size_t size, size_t align);
+    /* String duplication and error handling */
+    ARENA_API char* arena_strdup(Arena* a, const char* s);
+    ARENA_API char* arena_strdup_safe(Arena* a, const char* s);
+    ARENA_API void* arena_push_size_safe(Arena* a, size_t size, size_t align);
 
 #ifdef ARENA_IMPLEMENTATION
 
@@ -68,107 +78,136 @@ ARENA_API void *arena_push_size_safe(Arena *a, size_t size, size_t align);
 #include <stdlib.h>
 #include <assert.h>
 
-ARENA_API size_t arena_align_forward(size_t p, size_t a) {
-    if (a == 0) a = sizeof(void*); // Use pointer size as default alignment
-    return (p + (a - 1)) & ~(a - 1);
-}
+    ARENA_API size_t arena_align_forward(size_t p, size_t a)
+    {
+        if (a == 0)
+            a = sizeof(void*); // Use pointer size as default alignment
+        return (p + (a - 1)) & ~(a - 1);
+    }
 
-ARENA_API Arena arena_create(size_t reserve) {
-    Arena a = {0};
+    ARENA_API Arena arena_create(size_t reserve)
+    {
+        Arena a = {0};
 #ifdef _WIN32
-    a.base = VirtualAlloc(NULL, reserve, MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
-    if (!a.base) return a;
-    a.size = reserve;
-#ifdef ARENA_ENABLE_COMMIT
-    a.commit = reserve;
-#endif
-#else
-    int prot = PROT_READ | PROT_WRITE;
-    int flags = MAP_PRIVATE | MAP_ANONYMOUS;
-    void *ptr = mmap(NULL, reserve, prot, flags, -1, 0);
-    if (ptr == MAP_FAILED) {
-        ptr = malloc(reserve);
-        if (!ptr) return a;
-        a.base = ptr;
+        a.base = VirtualAlloc(NULL, reserve, MEM_RESERVE | MEM_COMMIT, PAGE_READWRITE);
+        if (!a.base)
+            return a;
         a.size = reserve;
 #ifdef ARENA_ENABLE_COMMIT
         a.commit = reserve;
 #endif
-    } else {
-        a.base = ptr;
-        a.size = reserve;
-#ifdef ARENA_ENABLE_COMMIT
-        a.commit = reserve;
-#endif
-    }
-#endif
-    return a;
-}
-
-ARENA_API void arena_destroy(Arena *a) {
-    if (!a || !a->base) return;
-#ifdef _WIN32
-    VirtualFree(a->base, 0, MEM_RELEASE);
 #else
-    munmap(a->base, a->size);
-#endif
-    a->base = NULL;
-    a->pos = 0;
-    a->size = 0;
+        int prot = PROT_READ | PROT_WRITE;
+        int flags = MAP_PRIVATE | MAP_ANONYMOUS;
+        void* ptr = mmap(NULL, reserve, prot, flags, -1, 0);
+        if (ptr == MAP_FAILED)
+        {
+            ptr = malloc(reserve);
+            if (!ptr)
+                return a;
+            a.base = ptr;
+            a.size = reserve;
 #ifdef ARENA_ENABLE_COMMIT
-    a->commit = 0;
+            a.commit = reserve;
 #endif
-}
+        }
+        else
+        {
+            a.base = ptr;
+            a.size = reserve;
+#ifdef ARENA_ENABLE_COMMIT
+            a.commit = reserve;
+#endif
+        }
+#endif
+        return a;
+    }
 
-ARENA_API void arena_clear(Arena *a) {
-    if (!a) return;
-    a->pos = 0;
+    ARENA_API void arena_destroy(Arena* a)
+    {
+        if (!a || !a->base)
+            return;
+#ifdef _WIN32
+        VirtualFree(a->base, 0, MEM_RELEASE);
+#else
+        munmap(a->base, a->size);
+#endif
+        a->base = NULL;
+        a->pos = 0;
+        a->size = 0;
+#ifdef ARENA_ENABLE_COMMIT
+        a->commit = 0;
+#endif
+    }
+
+    ARENA_API void arena_clear(Arena* a)
+    {
+        if (!a)
+            return;
+        a->pos = 0;
 #ifdef ARENA_ENABLE_COMMIT
 #endif
-}
-
-ARENA_API void *arena_push_size(Arena *a, size_t size, size_t align) {
-    if (!a || size == 0) return NULL;
-    size_t p = arena_align_forward(a->pos, align);
-    size_t new_pos = p + size;
-    if (new_pos > a->size) return NULL;
-    void *ptr = a->base + p;
-    memset(ptr, 0, size);
-    a->pos = new_pos;
-    return ptr;
-}
-
-ARENA_API size_t arena_get_mark(Arena *a) { return a ? a->pos : 0; }
-ARENA_API void arena_set_mark(Arena *a, size_t mark) { if (a) a->pos = mark; }
-
-/* Safe version that aborts on failure */
-ARENA_API void *arena_push_size_safe(Arena *a, size_t size, size_t align) {
-    void *p = arena_push_size(a, size, align);
-    if (!p && size > 0) {
-        fprintf(stderr, "FATAL: Out of memory allocating %zu bytes\n", size);
-        abort();
     }
-    return p;
-}
 
-/* Duplicate string using arena allocation */
-ARENA_API char *arena_strdup(Arena *a, const char *s) {
-    if (!s) return NULL;
-    size_t len = strlen(s) + 1;
-    char *p = (char *)arena_push_size(a, len, __alignof__(char));
-    if (p) memcpy(p, s, len);
-    return p;
-}
-
-/* Safe version that aborts on failure */
-ARENA_API char *arena_strdup_safe(Arena *a, const char *s) {
-    char *p = arena_strdup(a, s);
-    if (!p && s) {
-        fprintf(stderr, "FATAL: Out of memory duplicating string of length %zu\n", strlen(s));
-        abort();
+    ARENA_API void* arena_push_size(Arena* a, size_t size, size_t align)
+    {
+        if (!a || size == 0)
+            return NULL;
+        size_t p = arena_align_forward(a->pos, align);
+        size_t new_pos = p + size;
+        if (new_pos > a->size)
+            return NULL;
+        void* ptr = a->base + p;
+        memset(ptr, 0, size);
+        a->pos = new_pos;
+        return ptr;
     }
-    return p;
-}
+
+    ARENA_API size_t arena_get_mark(Arena* a)
+    {
+        return a ? a->pos : 0;
+    }
+    ARENA_API void arena_set_mark(Arena* a, size_t mark)
+    {
+        if (a)
+            a->pos = mark;
+    }
+
+    /* Safe version that aborts on failure */
+    ARENA_API void* arena_push_size_safe(Arena* a, size_t size, size_t align)
+    {
+        void* p = arena_push_size(a, size, align);
+        if (!p && size > 0)
+        {
+            fprintf(stderr, "FATAL: Out of memory allocating %zu bytes\n", size);
+            abort();
+        }
+        return p;
+    }
+
+    /* Duplicate string using arena allocation */
+    ARENA_API char* arena_strdup(Arena* a, const char* s)
+    {
+        if (!s)
+            return NULL;
+        size_t len = strlen(s) + 1;
+        char* p = (char*)arena_push_size(a, len, __alignof__(char));
+        if (p)
+            memcpy(p, s, len);
+        return p;
+    }
+
+    /* Safe version that aborts on failure */
+    ARENA_API char* arena_strdup_safe(Arena* a, const char* s)
+    {
+        char* p = arena_strdup(a, s);
+        if (!p && s)
+        {
+            fprintf(stderr, "FATAL: Out of memory duplicating string of length %zu\n", strlen(s));
+            abort();
+        }
+        return p;
+    }
 
 #endif /* ARENA_IMPLEMENTATION */
 

--- a/config.c
+++ b/config.c
@@ -12,82 +12,97 @@
 #include "arena.h"
 #include "debug.h"
 
-static bool parse_toml_file(const char *path, ConfigSettings *settings, Arena *arena);
+static bool parse_toml_file(const char* path, ConfigSettings* settings, Arena* arena);
 
 // Skip config loading if environment variable is set
-bool config_should_skip(void) {
-    const char *no_config = getenv("LLM_CTX_NO_CONFIG");
-    if (no_config && strcmp(no_config, "1") == 0) {
+bool config_should_skip(void)
+{
+    const char* no_config = getenv("LLM_CTX_NO_CONFIG");
+    if (no_config && strcmp(no_config, "1") == 0)
+    {
         debug_printf("Config loading disabled by LLM_CTX_NO_CONFIG=1");
         return true;
     }
-    
+
     return false;
 }
 
 // Expand ~ in paths for home directory resolution
-char *config_expand_path(const char *path, Arena *arena) {
-    if (!path || path[0] != '~') {
+char* config_expand_path(const char* path, Arena* arena)
+{
+    if (!path || path[0] != '~')
+    {
         // No tilde to expand, return a copy
         return arena_strdup_safe(arena, path);
     }
-    
-    const char *home_dir = NULL;
-    
-    if (path[1] == '/' || path[1] == '\0') {
+
+    const char* home_dir = NULL;
+
+    if (path[1] == '/' || path[1] == '\0')
+    {
         // Simple ~ or ~/...
         home_dir = getenv("HOME");
-        if (!home_dir) {
-            struct passwd *pw = getpwuid(getuid());
-            if (pw) {
+        if (!home_dir)
+        {
+            struct passwd* pw = getpwuid(getuid());
+            if (pw)
+            {
                 home_dir = pw->pw_dir;
             }
         }
-        
-        if (!home_dir) {
+
+        if (!home_dir)
+        {
             // Can't expand, return as-is
             return arena_strdup_safe(arena, path);
         }
-        
+
         // Construct expanded path
         size_t home_len = strlen(home_dir);
         size_t path_len = strlen(path);
         size_t total_len = home_len + path_len; // -1 for ~, +1 for \0
-        
-        char *expanded = arena_push_array_safe(arena, char, total_len);
+
+        char* expanded = arena_push_array_safe(arena, char, total_len);
         strcpy(expanded, home_dir);
         strcat(expanded, path + 1); // Skip the ~
-        
+
         return expanded;
-    } else {
+    }
+    else
+    {
         // ~username/... format - not supported for now
         return arena_strdup_safe(arena, path);
     }
 }
 
 // Attempt to load config from a single path
-static bool try_load_config(const char *path, ConfigSettings *settings, Arena *arena) {
+static bool try_load_config(const char* path, ConfigSettings* settings, Arena* arena)
+{
     struct stat st;
-    if (stat(path, &st) != 0) {
+    if (stat(path, &st) != 0)
+    {
         return false;
     }
-    
-    if (!S_ISREG(st.st_mode)) {
+
+    if (!S_ISREG(st.st_mode))
+    {
         fprintf(stderr, "Warning: %s is not a regular file\n", path);
         return false;
     }
-    
+
     debug_printf("Found config file: %s", path);
-    
+
     return parse_toml_file(path, settings, arena);
 }
 
 // Load config from standard locations in priority order
-bool config_load(ConfigSettings *settings, Arena *arena) {
-    if (!settings || !arena) {
+bool config_load(ConfigSettings* settings, Arena* arena)
+{
+    if (!settings || !arena)
+    {
         return false;
     }
-    
+
     memset(settings, 0, sizeof(ConfigSettings));
     settings->copy_to_clipboard = -1;
     settings->token_budget = 0;
@@ -98,51 +113,59 @@ bool config_load(ConfigSettings *settings, Arena *arena) {
     settings->filerank_weight_size = -1.0;
     settings->filerank_weight_tfidf = -1.0;
     settings->filerank_cutoff = NULL;
-    
-    if (config_should_skip()) {
+
+    if (config_should_skip())
+    {
         return false;
     }
-    
-    const char *paths_to_try[3] = {NULL, NULL, NULL};
+
+    const char* paths_to_try[3] = {NULL, NULL, NULL};
     int path_count = 0;
-    
-    const char *explicit_path = getenv("LLM_CTX_CONFIG");
-    if (explicit_path) {
+
+    const char* explicit_path = getenv("LLM_CTX_CONFIG");
+    if (explicit_path)
+    {
         paths_to_try[path_count++] = explicit_path;
     }
-    
-    const char *xdg_config = getenv("XDG_CONFIG_HOME");
+
+    const char* xdg_config = getenv("XDG_CONFIG_HOME");
     char xdg_path[PATH_MAX];
-    if (xdg_config) {
+    if (xdg_config)
+    {
         snprintf(xdg_path, sizeof(xdg_path), "%s/llm_ctx/config.toml", xdg_config);
         paths_to_try[path_count++] = xdg_path;
     }
-    
-    const char *home = getenv("HOME");
+
+    const char* home = getenv("HOME");
     char home_path[PATH_MAX];
-    if (home) {
+    if (home)
+    {
         snprintf(home_path, sizeof(home_path), "%s/.config/llm_ctx/config.toml", home);
         paths_to_try[path_count++] = home_path;
     }
-    
-    for (int i = 0; i < path_count; i++) {
-        if (try_load_config(paths_to_try[i], settings, arena)) {
+
+    for (int i = 0; i < path_count; i++)
+    {
+        if (try_load_config(paths_to_try[i], settings, arena))
+        {
             return true;
         }
     }
-    
+
     debug_printf("No config file found");
     return false;
 }
 
 // Print config for debugging
-void config_debug_print(const ConfigSettings *settings) {
-    if (!settings) return;
-    
+void config_debug_print(const ConfigSettings* settings)
+{
+    if (!settings)
+        return;
+
     fprintf(stderr, "[DEBUG] ConfigSettings:\n");
-    fprintf(stderr, "[DEBUG]   system_prompt_file: %s\n", 
+    fprintf(stderr, "[DEBUG]   system_prompt_file: %s\n",
             settings->system_prompt_file ? settings->system_prompt_file : "(null)");
-    fprintf(stderr, "[DEBUG]   response_guide_file: %s\n", 
+    fprintf(stderr, "[DEBUG]   response_guide_file: %s\n",
             settings->response_guide_file ? settings->response_guide_file : "(null)");
     fprintf(stderr, "[DEBUG]   copy_to_clipboard: %d\n", settings->copy_to_clipboard);
     fprintf(stderr, "[DEBUG]   token_budget: %zu\n", settings->token_budget);
@@ -150,238 +173,291 @@ void config_debug_print(const ConfigSettings *settings) {
     fprintf(stderr, "[DEBUG]   filerank_weight_content: %.2f\n", settings->filerank_weight_content);
     fprintf(stderr, "[DEBUG]   filerank_weight_size: %.2f\n", settings->filerank_weight_size);
     fprintf(stderr, "[DEBUG]   filerank_weight_tfidf: %.2f\n", settings->filerank_weight_tfidf);
-    fprintf(stderr, "[DEBUG]   filerank_cutoff: %s\n", settings->filerank_cutoff ? settings->filerank_cutoff : "(unset)");
+    fprintf(stderr, "[DEBUG]   filerank_cutoff: %s\n",
+            settings->filerank_cutoff ? settings->filerank_cutoff : "(unset)");
     fprintf(stderr, "[DEBUG]   template_count: %zu\n", settings->template_count);
-    
-    for (size_t i = 0; i < settings->template_count; i++) {
-        ConfigTemplate *tmpl = &settings->templates[i];
+
+    for (size_t i = 0; i < settings->template_count; i++)
+    {
+        ConfigTemplate* tmpl = &settings->templates[i];
         fprintf(stderr, "[DEBUG]   Template '%s':\n", tmpl->name);
-        fprintf(stderr, "[DEBUG]     system_prompt_file: %s\n", 
+        fprintf(stderr, "[DEBUG]     system_prompt_file: %s\n",
                 tmpl->system_prompt_file ? tmpl->system_prompt_file : "(null)");
-        fprintf(stderr, "[DEBUG]     response_guide_file: %s\n", 
+        fprintf(stderr, "[DEBUG]     response_guide_file: %s\n",
                 tmpl->response_guide_file ? tmpl->response_guide_file : "(null)");
     }
 }
 
 // Parse templates using state machine for [templates.name] sections
-static void parse_templates(FILE *fp, ConfigSettings *settings, Arena *arena) {
-    enum {
+static void parse_templates(FILE* fp, ConfigSettings* settings, Arena* arena)
+{
+    enum
+    {
         STATE_TOP,
         STATE_IN_TEMPLATES,
         STATE_IN_TEMPLATE
     } state = STATE_TOP;
-    
+
     char line[1024];
     char current_template[256] = {0};
-    ConfigTemplate *current_tmpl = NULL;
-    
+    ConfigTemplate* current_tmpl = NULL;
+
     size_t template_count = 0;
     long start_pos = ftell(fp);
-    
-    while (fgets(line, sizeof(line), fp)) {
-        char *p = line;
-        while (*p && isspace(*p)) p++;
-        
-        if (*p == '#' || *p == '\0') continue;
-        
-        if (*p == '[' && strncmp(p, "[templates.", 11) == 0) {
+
+    while (fgets(line, sizeof(line), fp))
+    {
+        char* p = line;
+        while (*p && isspace(*p))
+            p++;
+
+        if (*p == '#' || *p == '\0')
+            continue;
+
+        if (*p == '[' && strncmp(p, "[templates.", 11) == 0)
+        {
             template_count++;
         }
     }
-    
-    if (template_count > 0) {
+
+    if (template_count > 0)
+    {
         settings->templates = arena_push_array_safe(arena, ConfigTemplate, template_count);
         settings->template_count = 0;
     }
-    
+
     fseek(fp, start_pos, SEEK_SET);
-    
-    while (fgets(line, sizeof(line), fp)) {
+
+    while (fgets(line, sizeof(line), fp))
+    {
         // Remove trailing newline
         size_t len = strlen(line);
-        if (len > 0 && line[len-1] == '\n') line[len-1] = '\0';
-        
+        if (len > 0 && line[len - 1] == '\n')
+            line[len - 1] = '\0';
+
         // Skip whitespace
-        char *p = line;
-        while (*p && isspace(*p)) p++;
-        
+        char* p = line;
+        while (*p && isspace(*p))
+            p++;
+
         // Skip comments and empty lines
-        if (*p == '#' || *p == '\0') continue;
-        
+        if (*p == '#' || *p == '\0')
+            continue;
+
         // Handle section headers
-        if (*p == '[') {
-            char *end = strchr(p, ']');
-            if (!end) continue;
+        if (*p == '[')
+        {
+            char* end = strchr(p, ']');
+            if (!end)
+                continue;
             *end = '\0';
             p++; // Skip '['
-            
-            if (strcmp(p, "templates") == 0) {
+
+            if (strcmp(p, "templates") == 0)
+            {
                 state = STATE_IN_TEMPLATES;
-            } else if (strncmp(p, "templates.", 10) == 0) {
+            }
+            else if (strncmp(p, "templates.", 10) == 0)
+            {
                 state = STATE_IN_TEMPLATE;
                 strcpy(current_template, p + 10);
-                
+
                 // Create new template
                 current_tmpl = &settings->templates[settings->template_count++];
                 current_tmpl->name = arena_strdup_safe(arena, current_template);
                 current_tmpl->system_prompt_file = NULL;
                 current_tmpl->response_guide_file = NULL;
-            } else {
+            }
+            else
+            {
                 state = STATE_TOP;
                 current_tmpl = NULL;
             }
             continue;
         }
-        
+
         // Handle key-value pairs
-        if (state == STATE_IN_TEMPLATE && current_tmpl) {
-            char *eq = strchr(p, '=');
-            if (!eq) continue;
-            
+        if (state == STATE_IN_TEMPLATE && current_tmpl)
+        {
+            char* eq = strchr(p, '=');
+            if (!eq)
+                continue;
+
             *eq = '\0';
-            char *key = p;
-            char *value = eq + 1;
-            
+            char* key = p;
+            char* value = eq + 1;
+
             // Trim whitespace from key
-            char *key_end = key + strlen(key) - 1;
-            while (key_end > key && isspace(*key_end)) *key_end-- = '\0';
-            
+            char* key_end = key + strlen(key) - 1;
+            while (key_end > key && isspace(*key_end))
+                *key_end-- = '\0';
+
             // Trim whitespace from value
-            while (*value && isspace(*value)) value++;
-            
-            // Remove quotes if present
-            if (*value == '"') {
+            while (*value && isspace(*value))
                 value++;
-                char *quote_end = strrchr(value, '"');
-                if (quote_end) *quote_end = '\0';
+
+            // Remove quotes if present
+            if (*value == '"')
+            {
+                value++;
+                char* quote_end = strrchr(value, '"');
+                if (quote_end)
+                    *quote_end = '\0';
             }
-            
+
             // Store the values
-            if (strcmp(key, "system_prompt_file") == 0) {
+            if (strcmp(key, "system_prompt_file") == 0)
+            {
                 current_tmpl->system_prompt_file = arena_strdup_safe(arena, value);
-            } else if (strcmp(key, "response_guide_file") == 0) {
+            }
+            else if (strcmp(key, "response_guide_file") == 0)
+            {
                 current_tmpl->response_guide_file = arena_strdup_safe(arena, value);
             }
         }
     }
 }
 
-static bool parse_toml_file(const char *path, ConfigSettings *settings, Arena *arena) {
-    FILE *fp = fopen(path, "r");
-    if (!fp) {
+static bool parse_toml_file(const char* path, ConfigSettings* settings, Arena* arena)
+{
+    FILE* fp = fopen(path, "r");
+    if (!fp)
+    {
         return false;
     }
-    
+
     parse_templates(fp, settings, arena);
     rewind(fp);
-    
+
     char temp_path[PATH_MAX];
     snprintf(temp_path, sizeof(temp_path), "%s.tmp", path);
-    FILE *temp_fp = fopen(temp_path, "w");
-    if (!temp_fp) {
+    FILE* temp_fp = fopen(temp_path, "w");
+    if (!temp_fp)
+    {
         fclose(fp);
         return false;
     }
-    
+
     char line[1024];
     int skip_until_next_section = 0;
-    while (fgets(line, sizeof(line), fp)) {
-        if (line[0] == '[') {
-            if (strstr(line, "[templates.") != NULL) {
+    while (fgets(line, sizeof(line), fp))
+    {
+        if (line[0] == '[')
+        {
+            if (strstr(line, "[templates.") != NULL)
+            {
                 skip_until_next_section = 1;
                 continue;
-            } else {
+            }
+            else
+            {
                 skip_until_next_section = 0;
             }
         }
-        if (!skip_until_next_section) {
+        if (!skip_until_next_section)
+        {
             fputs(line, temp_fp);
         }
     }
     fclose(temp_fp);
-    
+
     temp_fp = fopen(temp_path, "r");
-    if (!temp_fp) {
+    if (!temp_fp)
+    {
         fclose(fp);
         unlink(temp_path);
         return false;
     }
-    
+
     char errbuf[200];
-    toml_table_t *conf = toml_parse_file(temp_fp, errbuf, sizeof(errbuf));
+    toml_table_t* conf = toml_parse_file(temp_fp, errbuf, sizeof(errbuf));
     fclose(temp_fp);
     unlink(temp_path);
-    
-    if (!conf) {
+
+    if (!conf)
+    {
         fprintf(stderr, "Error parsing config file %s: %s\n", path, errbuf);
         fclose(fp);
         return false;
     }
-    
+
     toml_datum_t system_prompt = toml_string_in(conf, "system_prompt_file");
-    if (system_prompt.ok) {
+    if (system_prompt.ok)
+    {
         settings->system_prompt_file = arena_strdup_safe(arena, system_prompt.u.s);
         free(system_prompt.u.s);
     }
-    
+
     toml_datum_t response_guide = toml_string_in(conf, "response_guide_file");
-    if (response_guide.ok) {
+    if (response_guide.ok)
+    {
         settings->response_guide_file = arena_strdup_safe(arena, response_guide.u.s);
         free(response_guide.u.s);
     }
-    
+
     toml_datum_t copy_clipboard = toml_bool_in(conf, "copy_to_clipboard");
-    if (copy_clipboard.ok) {
+    if (copy_clipboard.ok)
+    {
         settings->copy_to_clipboard = copy_clipboard.u.b ? 1 : 0;
     }
-    
+
     toml_datum_t token_budget = toml_int_in(conf, "token_budget");
-    if (token_budget.ok) {
+    if (token_budget.ok)
+    {
         settings->token_budget = (size_t)token_budget.u.i;
     }
-    
+
     toml_datum_t weight_path = toml_int_in(conf, "filerank_weight_path_x100");
-    if (weight_path.ok) {
+    if (weight_path.ok)
+    {
         settings->filerank_weight_path = weight_path.u.i / 100.0;
     }
-    
+
     toml_datum_t weight_content = toml_int_in(conf, "filerank_weight_content_x100");
-    if (weight_content.ok) {
+    if (weight_content.ok)
+    {
         settings->filerank_weight_content = weight_content.u.i / 100.0;
     }
-    
+
     toml_datum_t weight_size = toml_int_in(conf, "filerank_weight_size_x100");
-    if (weight_size.ok) {
+    if (weight_size.ok)
+    {
         settings->filerank_weight_size = weight_size.u.i / 100.0;
     }
-    
+
     toml_datum_t weight_tfidf = toml_int_in(conf, "filerank_weight_tfidf_x100");
-    if (weight_tfidf.ok) {
+    if (weight_tfidf.ok)
+    {
         settings->filerank_weight_tfidf = weight_tfidf.u.i / 100.0;
     }
-    
+
     toml_datum_t cutoff = toml_string_in(conf, "filerank_cutoff");
-    if (cutoff.ok) {
+    if (cutoff.ok)
+    {
         settings->filerank_cutoff = arena_strdup_safe(arena, cutoff.u.s);
         free(cutoff.u.s);
     }
-    
+
     toml_free(conf);
     fclose(fp);
     return true;
 }
 
 // Find template by name
-ConfigTemplate *config_find_template(const ConfigSettings *settings, const char *name) {
-    if (!settings || !name || !settings->templates) {
+ConfigTemplate* config_find_template(const ConfigSettings* settings, const char* name)
+{
+    if (!settings || !name || !settings->templates)
+    {
         return NULL;
     }
-    
-    for (size_t i = 0; i < settings->template_count; i++) {
-        if (strcmp(settings->templates[i].name, name) == 0) {
+
+    for (size_t i = 0; i < settings->template_count; i++)
+    {
+        if (strcmp(settings->templates[i].name, name) == 0)
+        {
             return &settings->templates[i];
         }
     }
-    
+
     return NULL;
 }

--- a/config.h
+++ b/config.h
@@ -7,40 +7,42 @@
 // Forward declaration
 struct Arena;
 
-typedef struct {
-    char *name;                   // Template name
-    char *system_prompt_file;     // System prompt file path
-    char *response_guide_file;    // Response guide file path
+typedef struct
+{
+    char* name;                // Template name
+    char* system_prompt_file;  // System prompt file path
+    char* response_guide_file; // Response guide file path
 } ConfigTemplate;
 
-typedef struct {
-    char *system_prompt_file;     // NULL → none
-    char *response_guide_file;    // NULL → none
-    int copy_to_clipboard;        // tri-state: -1=unset, 0=false, 1=true
-    size_t token_budget;          // 0 → unset
-    ConfigTemplate *templates;    // Array of named templates
-    size_t template_count;        // Number of templates
+typedef struct
+{
+    char* system_prompt_file;  // NULL → none
+    char* response_guide_file; // NULL → none
+    int copy_to_clipboard;     // tri-state: -1=unset, 0=false, 1=true
+    size_t token_budget;       // 0 → unset
+    ConfigTemplate* templates; // Array of named templates
+    size_t template_count;     // Number of templates
     // FileRank weight configuration
-    double filerank_weight_path;      // -1.0 → unset
-    double filerank_weight_content;   // -1.0 → unset
-    double filerank_weight_size;      // -1.0 → unset
-    double filerank_weight_tfidf;     // -1.0 → unset
-    char *filerank_cutoff;            // NULL → unset
+    double filerank_weight_path;    // -1.0 → unset
+    double filerank_weight_content; // -1.0 → unset
+    double filerank_weight_size;    // -1.0 → unset
+    double filerank_weight_tfidf;   // -1.0 → unset
+    char* filerank_cutoff;          // NULL → unset
 } ConfigSettings;
 
 // Load config from standard locations
-bool config_load(ConfigSettings *settings, struct Arena *arena);
+bool config_load(ConfigSettings* settings, struct Arena* arena);
 
 // Skip config loading if environment variable is set
 bool config_should_skip(void);
 
 // Expand ~ in paths for home directory resolution
-char *config_expand_path(const char *path, struct Arena *arena);
+char* config_expand_path(const char* path, struct Arena* arena);
 
 // Print config for debugging
-void config_debug_print(const ConfigSettings *settings);
+void config_debug_print(const ConfigSettings* settings);
 
 // Find template by name
-ConfigTemplate *config_find_template(const ConfigSettings *settings, const char *name);
+ConfigTemplate* config_find_template(const ConfigSettings* settings, const char* name);
 
 #endif // CONFIG_H

--- a/debug.h
+++ b/debug.h
@@ -9,65 +9,72 @@
 extern bool debug_mode;
 
 // Debug print with suppression of repetitive messages
-static inline void debug_printf(const char *fmt, ...) {
-    const char *always_suppress[] = {
-        "[DEBUG] Initializing language pack: ",
-        "[DEBUG] Cleaning up language pack: ",
-        "[DEBUG] Parsing file with language pack: "
-    };
-    
-    const char *non_debug_suppress[] = {
-        "Successfully extracted",
-        "Codemap option enabled",
-        "Generating codemap",
-        "Generating codemap with",
-        "Pattern ",
-        "Loaded ",
-        "Recursively scanning",
-        "Searching for ",
-        "Matched pattern",
-        "Processing ",
-        "Success: Parsed",
-        "Codemap generation complete",
-        "Successfully built codemap",
-        "Codemap generated successfully"
-    };
-    
+static inline void debug_printf(const char* fmt, ...)
+{
+    const char* always_suppress[] = {
+        "[DEBUG] Initializing language pack: ", "[DEBUG] Cleaning up language pack: ",
+        "[DEBUG] Parsing file with language pack: "};
+
+    const char* non_debug_suppress[] = {"Successfully extracted",
+                                        "Codemap option enabled",
+                                        "Generating codemap",
+                                        "Generating codemap with",
+                                        "Pattern ",
+                                        "Loaded ",
+                                        "Recursively scanning",
+                                        "Searching for ",
+                                        "Matched pattern",
+                                        "Processing ",
+                                        "Success: Parsed",
+                                        "Codemap generation complete",
+                                        "Successfully built codemap",
+                                        "Codemap generated successfully"};
+
     /* Check if this message should be always suppressed */
-    for (size_t i = 0; i < sizeof(always_suppress) / sizeof(always_suppress[0]); i++) {
-        if (strstr(fmt, always_suppress[i]) != NULL) {
+    for (size_t i = 0; i < sizeof(always_suppress) / sizeof(always_suppress[0]); i++)
+    {
+        if (strstr(fmt, always_suppress[i]) != NULL)
+        {
             return; /* Just exit, don't print anything */
         }
     }
-    
+
     /* Check if this message should be suppressed in non-debug mode */
-    if (!debug_mode) {
-        for (size_t i = 0; i < sizeof(non_debug_suppress) / sizeof(non_debug_suppress[0]); i++) {
-            if (strstr(fmt, non_debug_suppress[i]) != NULL) {
+    if (!debug_mode)
+    {
+        for (size_t i = 0; i < sizeof(non_debug_suppress) / sizeof(non_debug_suppress[0]); i++)
+        {
+            if (strstr(fmt, non_debug_suppress[i]) != NULL)
+            {
                 return; /* Just exit, don't print anything */
             }
         }
     }
-    
+
     /* If we get here, the message should be printed */
     va_list ap;
     va_start(ap, fmt);
-    
-    if (debug_mode) {
+
+    if (debug_mode)
+    {
         /* In debug mode, prefix with [DEBUG] */
         fprintf(stderr, "[DEBUG] ");
         vfprintf(stderr, fmt, ap);
-        if (fmt[0] != '\0' && fmt[strlen(fmt) - 1] != '\n') {
-            fputc('\n', stderr);
-        }
-    } else {
-        /* In normal mode, just print the message */
-        vfprintf(stderr, fmt, ap);
-        if (fmt[0] != '\0' && fmt[strlen(fmt) - 1] != '\n') {
+        if (fmt[0] != '\0' && fmt[strlen(fmt) - 1] != '\n')
+        {
             fputc('\n', stderr);
         }
     }
-    
+    else
+    {
+        /* In normal mode, just print the message */
+        vfprintf(stderr, fmt, ap);
+        if (fmt[0] != '\0' && fmt[strlen(fmt) - 1] != '\n')
+        {
+            fputc('\n', stderr);
+        }
+    }
+
     va_end(ap);
 }
 

--- a/gitignore.c
+++ b/gitignore.c
@@ -5,7 +5,8 @@ int num_ignore_patterns = 0;
 bool respect_gitignore = true;
 
 // Reset patterns for testing
-void reset_gitignore_patterns(void) {
+void reset_gitignore_patterns(void)
+{
     num_ignore_patterns = 0;
     respect_gitignore = true;
     assert(num_ignore_patterns == 0);
@@ -13,167 +14,190 @@ void reset_gitignore_patterns(void) {
 }
 
 // Check if path matches gitignore patterns (later patterns override earlier ones)
-int should_ignore_path(const char *path) {
+int should_ignore_path(const char* path)
+{
     assert(path != NULL);
-    
-    if (!respect_gitignore || num_ignore_patterns == 0) {
+
+    if (!respect_gitignore || num_ignore_patterns == 0)
+    {
         return 0;
     }
-    
-    const char *basename = strrchr(path, '/');
-    if (basename) {
+
+    const char* basename = strrchr(path, '/');
+    if (basename)
+    {
         basename++;
-        assert(*(basename-1) == '/');
-    } else {
+        assert(*(basename - 1) == '/');
+    }
+    else
+    {
         basename = path;
     }
-    
+
     assert(basename != NULL);
-    
+
     struct stat path_stat;
     bool is_dir = false;
-    if (lstat(path, &path_stat) == 0) {
+    if (lstat(path, &path_stat) == 0)
+    {
         is_dir = S_ISDIR(path_stat.st_mode);
     }
-    
+
     bool negated = false;
-    
-    for (int i = num_ignore_patterns - 1; i >= 0; i--) {
-        if (ignore_patterns[i].match_only_dir && !is_dir) {
+
+    for (int i = num_ignore_patterns - 1; i >= 0; i--)
+    {
+        if (ignore_patterns[i].match_only_dir && !is_dir)
+        {
             continue;
         }
-        
+
         int path_match = fnmatch(ignore_patterns[i].pattern, path, FNM_PATHNAME) == 0;
         int basename_match = fnmatch(ignore_patterns[i].pattern, basename, 0) == 0;
-        
+
         assert(path_match == (fnmatch(ignore_patterns[i].pattern, path, FNM_PATHNAME) == 0));
         assert(basename_match == (fnmatch(ignore_patterns[i].pattern, basename, 0) == 0));
-        
-        if (path_match || basename_match) {
-            if (ignore_patterns[i].is_negation) {
+
+        if (path_match || basename_match)
+        {
+            if (ignore_patterns[i].is_negation)
+            {
                 return 0;
             }
-            
-            if (!negated) {
+
+            if (!negated)
+            {
                 return 1;
             }
         }
     }
-    
+
     return 0;
 }
 
 // Add pattern to ignore list with whitespace trimming and negation support
-void add_ignore_pattern(char *pattern) {
+void add_ignore_pattern(char* pattern)
+{
     assert(pattern != NULL);
     assert(num_ignore_patterns < MAX_IGNORE_PATTERNS);
-    
-    if (num_ignore_patterns >= MAX_IGNORE_PATTERNS) {
+
+    if (num_ignore_patterns >= MAX_IGNORE_PATTERNS)
+    {
         return;
     }
-    
-    while (*pattern && isspace(*pattern)) {
+
+    while (*pattern && isspace(*pattern))
+    {
         pattern++;
     }
-    
-    char *end = pattern + strlen(pattern) - 1;
-    while (end > pattern && isspace(*end)) {
+
+    char* end = pattern + strlen(pattern) - 1;
+    while (end > pattern && isspace(*end))
+    {
         *end-- = '\0';
     }
-    
-    if (*pattern == '\0' || *pattern == '#') {
+
+    if (*pattern == '\0' || *pattern == '#')
+    {
         return;
     }
-    
+
     bool is_negation = false;
-    if (*pattern == '!') {
+    if (*pattern == '!')
+    {
         is_negation = true;
         pattern++;
     }
-    
+
     bool match_only_dir = false;
     size_t len = strlen(pattern);
-    if (len > 0 && pattern[len - 1] == '/') {
+    if (len > 0 && pattern[len - 1] == '/')
+    {
         match_only_dir = true;
         pattern[len - 1] = '\0';
     }
-    
+
     IgnorePattern new_pattern = {
-        .pattern = "",
-        .is_negation = is_negation,
-        .match_only_dir = match_only_dir
-    };
+        .pattern = "", .is_negation = is_negation, .match_only_dir = match_only_dir};
     strncpy(new_pattern.pattern, pattern, MAX_PATH - 1);
     new_pattern.pattern[MAX_PATH - 1] = '\0';
     ignore_patterns[num_ignore_patterns] = new_pattern;
-    
+
     assert(num_ignore_patterns < MAX_IGNORE_PATTERNS);
     num_ignore_patterns++;
-    
-    assert(strcmp(ignore_patterns[num_ignore_patterns-1].pattern, pattern) == 0);
-    assert(ignore_patterns[num_ignore_patterns-1].is_negation == is_negation);
-    assert(ignore_patterns[num_ignore_patterns-1].match_only_dir == match_only_dir);
+
+    assert(strcmp(ignore_patterns[num_ignore_patterns - 1].pattern, pattern) == 0);
+    assert(ignore_patterns[num_ignore_patterns - 1].is_negation == is_negation);
+    assert(ignore_patterns[num_ignore_patterns - 1].match_only_dir == match_only_dir);
 }
 
 /**
  * Load patterns from a .gitignore file
  */
-void load_gitignore_file(const char *filepath) {
+void load_gitignore_file(const char* filepath)
+{
     assert(filepath != NULL);
-    
-    FILE *file = fopen(filepath, "r");
-    if (!file) {
+
+    FILE* file = fopen(filepath, "r");
+    if (!file)
+    {
         return;
     }
-    
+
     char line[MAX_PATH];
-    while (fgets(line, sizeof(line), file)) {
+    while (fgets(line, sizeof(line), file))
+    {
         /* Remove trailing newline */
         size_t len = strlen(line);
-        if (len > 0 && line[len - 1] == '\n') {
+        if (len > 0 && line[len - 1] == '\n')
+        {
             line[len - 1] = '\0';
         }
-        
+
         add_ignore_pattern(line);
     }
-    
+
     fclose(file);
 }
 
 /**
  * Load all .gitignore files from the current directory and parent directories
  */
-void load_all_gitignore_files(void) {
+void load_all_gitignore_files(void)
+{
     char current_dir[MAX_PATH];
     char gitignore_path[MAX_PATH * 2];
-    
+
     assert(num_ignore_patterns < MAX_IGNORE_PATTERNS);
-    
+
     /* Get the current working directory */
-    if (getcwd(current_dir, sizeof(current_dir)) == NULL) {
+    if (getcwd(current_dir, sizeof(current_dir)) == NULL)
+    {
         return;
     }
-    
+
     assert(current_dir[0] != '\0');
-    
+
     /* First, try to load .gitignore from the current directory */
     snprintf(gitignore_path, sizeof(gitignore_path), "%s/.gitignore", current_dir);
     load_gitignore_file(gitignore_path);
-    
+
     /* Then, try to load from parent directories */
-    char *dir = current_dir;
-    char *last_slash;
-    
-    while ((last_slash = strrchr(dir, '/')) != NULL) {
+    char* dir = current_dir;
+    char* last_slash;
+
+    while ((last_slash = strrchr(dir, '/')) != NULL)
+    {
         /* Truncate path at the last slash to go up one directory */
         *last_slash = '\0';
-        
+
         /* Try to load .gitignore from this directory */
         snprintf(gitignore_path, sizeof(gitignore_path), "%s/.gitignore", dir);
         load_gitignore_file(gitignore_path);
-        
+
         /* Stop if we've reached the root directory */
-        if (last_slash == dir) {
+        if (last_slash == dir)
+        {
             break;
         }
     }

--- a/gitignore.h
+++ b/gitignore.h
@@ -14,14 +14,15 @@
 #include <stdint.h>
 
 // Compile-time size validation
-#define STATIC_ASSERT(cond, msg) typedef char static_assertion_##msg[(cond)?1:-1]
+#define STATIC_ASSERT(cond, msg) typedef char static_assertion_##msg[(cond) ? 1 : -1]
 STATIC_ASSERT(sizeof(size_t) >= 4, size_t_at_least_32_bits);
 
 #define MAX_PATH 4096
 #define MAX_IGNORE_PATTERNS 1024
 
 // Gitignore pattern with negation and directory matching support
-typedef struct {
+typedef struct
+{
     char pattern[MAX_PATH];
     bool is_negation;
     bool match_only_dir;
@@ -32,13 +33,13 @@ extern int num_ignore_patterns;
 extern bool respect_gitignore;
 
 // Check if path matches gitignore patterns
-int should_ignore_path(const char *path);
+int should_ignore_path(const char* path);
 
 // Add pattern to ignore list
-void add_ignore_pattern(char *pattern);
+void add_ignore_pattern(char* pattern);
 
 // Load patterns from .gitignore file
-void load_gitignore_file(const char *filepath);
+void load_gitignore_file(const char* filepath);
 
 // Load all .gitignore files from current and parent directories
 void load_all_gitignore_files(void);
@@ -47,4 +48,3 @@ void load_all_gitignore_files(void);
 void reset_gitignore_patterns(void);
 
 #endif /* GITIGNORE_H */
-

--- a/tokenizer.c
+++ b/tokenizer.c
@@ -12,115 +12,138 @@ typedef void CoreBPE;
 typedef uint32_t Rank;
 
 /* Function pointer types matching tiktoken-c API */
-typedef CoreBPE* (*get_bpe_from_model_fn)(const char *model);
-typedef Rank* (*encode_ordinary_fn)(CoreBPE *ptr, const char *text, size_t *num_tokens);
-typedef void (*destroy_corebpe_fn)(CoreBPE *ptr);
+typedef CoreBPE* (*get_bpe_from_model_fn)(const char* model);
+typedef Rank* (*encode_ordinary_fn)(CoreBPE* ptr, const char* text, size_t* num_tokens);
+typedef void (*destroy_corebpe_fn)(CoreBPE* ptr);
 typedef const char* (*version_fn)(void);
 
 /* Global state for dynamic loading */
-static void *g_tokenizer_lib = NULL;
+static void* g_tokenizer_lib = NULL;
 static get_bpe_from_model_fn g_get_bpe_from_model = NULL;
 static encode_ordinary_fn g_encode_ordinary = NULL;
 static destroy_corebpe_fn g_destroy_corebpe = NULL;
 static version_fn g_version_fn = NULL;
 static int g_load_attempted = 0;
 static int g_load_failed = 0;
-static char *g_executable_dir = NULL;
+static char* g_executable_dir = NULL;
 static char g_load_error[512];
 
-static void remember_dl_error(const char *err) {
-    if (err && *err) {
+static void remember_dl_error(const char* err)
+{
+    if (err && *err)
+    {
         snprintf(g_load_error, sizeof(g_load_error), "%s", err);
     }
 }
 
 /* Platform-specific library name */
 #ifdef __APPLE__
-    #define TOKENIZER_LIB_NAME "tokenizer/libtiktoken_c.dylib"
+#define TOKENIZER_LIB_NAME "tokenizer/libtiktoken_c.dylib"
 #elif defined(__linux__)
-    #define TOKENIZER_LIB_NAME "tokenizer/libtiktoken_c.so"
+#define TOKENIZER_LIB_NAME "tokenizer/libtiktoken_c.so"
 #elif defined(_WIN32)
-    #define TOKENIZER_LIB_NAME "tokenizer/libtiktoken_c.dll"
+#define TOKENIZER_LIB_NAME "tokenizer/libtiktoken_c.dll"
 #else
-    #define TOKENIZER_LIB_NAME "tokenizer/libtiktoken_c.so"
+#define TOKENIZER_LIB_NAME "tokenizer/libtiktoken_c.so"
 #endif
 
 /* Try to load the tokenizer library */
-static void load_tokenizer_lib(void) {
-    if (g_load_attempted) {
+static void load_tokenizer_lib(void)
+{
+    if (g_load_attempted)
+    {
         return;
     }
-    
+
     g_load_attempted = 1;
     g_load_error[0] = '\0';
-    
+
     /* Try to load the library */
     g_tokenizer_lib = dlopen(TOKENIZER_LIB_NAME, RTLD_LAZY);
-    if (!g_tokenizer_lib) {
+    if (!g_tokenizer_lib)
+    {
         /* Get error for debug */
-        const char *err = dlerror();
-        if (getenv("LLMCTX_DEBUG") && err) {
+        const char* err = dlerror();
+        if (getenv("LLMCTX_DEBUG") && err)
+        {
             fprintf(stderr, "debug: dlopen(%s) failed: %s\n", TOKENIZER_LIB_NAME, err);
         }
         remember_dl_error(err);
 
         /* Try with executable directory if set */
-        if (!g_tokenizer_lib && g_executable_dir) {
+        if (!g_tokenizer_lib && g_executable_dir)
+        {
             char exe_path[1024];
             snprintf(exe_path, sizeof(exe_path), "%s/%s", g_executable_dir, TOKENIZER_LIB_NAME);
             g_tokenizer_lib = dlopen(exe_path, RTLD_LAZY);
-            if (!g_tokenizer_lib && getenv("LLMCTX_DEBUG")) {
-                const char *path_err = dlerror();
+            if (!g_tokenizer_lib && getenv("LLMCTX_DEBUG"))
+            {
+                const char* path_err = dlerror();
                 fprintf(stderr, "debug: dlopen(%s) failed: %s\n", exe_path, path_err);
                 remember_dl_error(path_err);
-            } else if (!g_tokenizer_lib) {
+            }
+            else if (!g_tokenizer_lib)
+            {
                 remember_dl_error(dlerror());
             }
         }
 
         /* Try with absolute path from current directory */
-        if (!g_tokenizer_lib) {
+        if (!g_tokenizer_lib)
+        {
             char abs_path[1024];
-            if (getcwd(abs_path, sizeof(abs_path))) {
+            if (getcwd(abs_path, sizeof(abs_path)))
+            {
                 strcat(abs_path, "/");
                 strcat(abs_path, TOKENIZER_LIB_NAME);
                 g_tokenizer_lib = dlopen(abs_path, RTLD_LAZY);
-                if (!g_tokenizer_lib) {
+                if (!g_tokenizer_lib)
+                {
                     remember_dl_error(dlerror());
                 }
             }
         }
 
-        if (!g_tokenizer_lib) {
+        if (!g_tokenizer_lib)
+        {
             /* Try without path prefix in case it's in LD_LIBRARY_PATH */
             g_tokenizer_lib = dlopen("libtiktoken_c.so", RTLD_LAZY);
-            if (!g_tokenizer_lib) {
+            if (!g_tokenizer_lib)
+            {
                 g_tokenizer_lib = dlopen("libtiktoken_c.dylib", RTLD_LAZY);
-                if (!g_tokenizer_lib) {
+                if (!g_tokenizer_lib)
+                {
                     remember_dl_error(dlerror());
                 }
-            } else {
+            }
+            else
+            {
                 g_load_error[0] = '\0';
             }
         }
     }
-    
-    if (!g_tokenizer_lib) {
+
+    if (!g_tokenizer_lib)
+    {
         g_load_failed = 1;
         return;
     }
-    
+
     /* Look up the functions we need */
-    g_get_bpe_from_model = (get_bpe_from_model_fn)dlsym(g_tokenizer_lib, "tiktoken_get_bpe_from_model");
-    g_encode_ordinary = (encode_ordinary_fn)dlsym(g_tokenizer_lib, "tiktoken_corebpe_encode_ordinary");
+    g_get_bpe_from_model =
+        (get_bpe_from_model_fn)dlsym(g_tokenizer_lib, "tiktoken_get_bpe_from_model");
+    g_encode_ordinary =
+        (encode_ordinary_fn)dlsym(g_tokenizer_lib, "tiktoken_corebpe_encode_ordinary");
     g_destroy_corebpe = (destroy_corebpe_fn)dlsym(g_tokenizer_lib, "tiktoken_destroy_corebpe");
     g_version_fn = (version_fn)dlsym(g_tokenizer_lib, "tiktoken_c_version");
-    
-    if (!g_get_bpe_from_model || !g_encode_ordinary || !g_destroy_corebpe) {
+
+    if (!g_get_bpe_from_model || !g_encode_ordinary || !g_destroy_corebpe)
+    {
         dlclose(g_tokenizer_lib);
         g_tokenizer_lib = NULL;
         g_load_failed = 1;
-        snprintf(g_load_error, sizeof(g_load_error), "missing required symbols in tokenizer library");
+        snprintf(g_load_error, sizeof(g_load_error),
+                 "missing required symbols in tokenizer library");
         return;
     }
 
@@ -128,74 +151,89 @@ static void load_tokenizer_lib(void) {
     g_load_error[0] = '\0';
 }
 
-static void ensure_tokenizer_ready(void) {
+static void ensure_tokenizer_ready(void)
+{
     load_tokenizer_lib();
-    if (g_load_failed || !g_tokenizer_lib || !g_get_bpe_from_model || !g_encode_ordinary || !g_destroy_corebpe) {
-        const char *detail = g_load_error[0] ? g_load_error : "tokenizer library not found";
+    if (g_load_failed || !g_tokenizer_lib || !g_get_bpe_from_model || !g_encode_ordinary ||
+        !g_destroy_corebpe)
+    {
+        const char* detail = g_load_error[0] ? g_load_error : "tokenizer library not found";
         fprintf(stderr, "fatal: tokenizer unavailable (%s)\n", detail);
         fprintf(stderr, "hint: run `make tokenizer` to build the vendored tokenizer library\n");
         exit(EXIT_FAILURE);
     }
 }
 
-size_t llm_count_tokens(const char *text, const char *model) {
-    if (!text || !model) {
+size_t llm_count_tokens(const char* text, const char* model)
+{
+    if (!text || !model)
+    {
         return SIZE_MAX;
     }
-    
+
     /* Ensure library is loaded */
     ensure_tokenizer_ready();
-    
+
     /* Validate model string */
     assert(model != NULL);
     assert(strlen(model) > 0);
     assert(strlen(model) < 256); /* Reasonable model name length */
-    
+
     /* Get the BPE encoder for the model */
-    CoreBPE *bpe = g_get_bpe_from_model(model);
-    if (!bpe) {
+    CoreBPE* bpe = g_get_bpe_from_model(model);
+    if (!bpe)
+    {
         fprintf(stderr, "fatal: tokenizer model '%s' not supported\n", model);
         fprintf(stderr, "hint: choose a supported model or update the vendored tokenizer\n");
         exit(EXIT_FAILURE);
     }
-    
+
     /* Validate BPE encoder */
     assert(bpe != NULL);
-    
+
     /* Encode the text */
     size_t num_tokens = 0;
-    Rank *tokens = g_encode_ordinary(bpe, text, &num_tokens);
-    
+    Rank* tokens = g_encode_ordinary(bpe, text, &num_tokens);
+
     /* Assert that we got a reasonable token count */
-    if (num_tokens > 0 && num_tokens < SIZE_MAX) {
+    if (num_tokens > 0 && num_tokens < SIZE_MAX)
+    {
         /* Sanity check: token count should be reasonable compared to text length */
         size_t text_len = strlen(text);
         /* Most text has between 1 token per 6 chars to 1 token per 2 chars */
-        if (num_tokens > text_len) {
-            fprintf(stderr, "warning: suspicious token count %zu for text length %zu\n", num_tokens, text_len);
+        if (num_tokens > text_len)
+        {
+            fprintf(stderr, "warning: suspicious token count %zu for text length %zu\n", num_tokens,
+                    text_len);
         }
     }
-    
+
     /* Clean up */
-    if (tokens && tokens != (Rank *)0x4) {
+    if (tokens && tokens != (Rank*)0x4)
+    {
         /* Only free if it's a valid heap pointer */
-        if ((uintptr_t)tokens > 0x1000) {
+        if ((uintptr_t)tokens > 0x1000)
+        {
             free(tokens);
         }
     }
     g_destroy_corebpe(bpe);
-    
+
     return num_tokens;
 }
 
-int llm_tokenizer_available(void) {
+int llm_tokenizer_available(void)
+{
     load_tokenizer_lib();
     return g_tokenizer_lib != NULL && g_get_bpe_from_model != NULL;
 }
 
-void llm_set_executable_dir(const char *dir) {
-    if (dir && *dir) {
-        if (g_executable_dir) {
+void llm_set_executable_dir(const char* dir)
+{
+    if (dir && *dir)
+    {
+        if (g_executable_dir)
+        {
             free(g_executable_dir);
         }
         g_executable_dir = strdup(dir);

--- a/tokenizer.h
+++ b/tokenizer.h
@@ -8,15 +8,16 @@
 struct Arena;
 
 // Count tokens using tiktoken library (lazy-loaded)
-size_t llm_count_tokens(const char *text, const char *model);
+size_t llm_count_tokens(const char* text, const char* model);
 
 // Check if tokenizer library is available
 int llm_tokenizer_available(void);
 
 // Set executable directory for library discovery
-void llm_set_executable_dir(const char *dir);
+void llm_set_executable_dir(const char* dir);
 
 // Generate token breakdown by file and section
-void generate_token_diagnostics(const char *content, const char *model, FILE *out, struct Arena *arena);
+void generate_token_diagnostics(const char* content, const char* model, FILE* out,
+                                struct Arena* arena);
 
 #endif /* TOKENIZER_H */

--- a/tokenizer/tiktoken.h
+++ b/tokenizer/tiktoken.h
@@ -11,58 +11,53 @@
 typedef void CoreBPE;
 typedef uint32_t Rank;
 
-typedef struct CFunctionCall {
-  const char *name;
-  const char *arguments;
+typedef struct CFunctionCall
+{
+    const char* name;
+    const char* arguments;
 } CFunctionCall;
 
-typedef struct CChatCompletionRequestMessage {
-  const char *role;
-  const char *content;
-  const char *name;
-  const struct CFunctionCall *function_call;
+typedef struct CChatCompletionRequestMessage
+{
+    const char* role;
+    const char* content;
+    const char* name;
+    const struct CFunctionCall* function_call;
 } CChatCompletionRequestMessage;
 
-const char *tiktoken_c_version(void);
+const char* tiktoken_c_version(void);
 
 void tiktoken_init_logger(void);
 
-CoreBPE *tiktoken_r50k_base(void);
+CoreBPE* tiktoken_r50k_base(void);
 
-CoreBPE *tiktoken_p50k_base(void);
+CoreBPE* tiktoken_p50k_base(void);
 
-CoreBPE *tiktoken_p50k_edit(void);
+CoreBPE* tiktoken_p50k_edit(void);
 
-CoreBPE *tiktoken_cl100k_base(void);
+CoreBPE* tiktoken_cl100k_base(void);
 
-CoreBPE *tiktoken_o200k_base(void);
+CoreBPE* tiktoken_o200k_base(void);
 
-void tiktoken_destroy_corebpe(CoreBPE *ptr);
+void tiktoken_destroy_corebpe(CoreBPE* ptr);
 
-CoreBPE *tiktoken_get_bpe_from_model(const char *model);
+CoreBPE* tiktoken_get_bpe_from_model(const char* model);
 
-size_t tiktoken_get_completion_max_tokens(const char *model, const char *prompt);
+size_t tiktoken_get_completion_max_tokens(const char* model, const char* prompt);
 
-size_t tiktoken_num_tokens_from_messages(const char *model,
-                                         uint32_t num_messages,
-                                         const struct CChatCompletionRequestMessage *messages);
+size_t tiktoken_num_tokens_from_messages(const char* model, uint32_t num_messages,
+                                         const struct CChatCompletionRequestMessage* messages);
 
-size_t tiktoken_get_chat_completion_max_tokens(const char *model,
-                                               uint32_t num_messages,
-                                               const struct CChatCompletionRequestMessage *messages);
+size_t
+tiktoken_get_chat_completion_max_tokens(const char* model, uint32_t num_messages,
+                                        const struct CChatCompletionRequestMessage* messages);
 
-Rank *tiktoken_corebpe_encode_ordinary(CoreBPE *ptr, const char *text, size_t *num_tokens);
+Rank* tiktoken_corebpe_encode_ordinary(CoreBPE* ptr, const char* text, size_t* num_tokens);
 
-Rank *tiktoken_corebpe_encode(CoreBPE *ptr,
-                              const char *text,
-                              const char *const *allowed_special,
-                              size_t allowed_special_len,
-                              size_t *num_tokens);
+Rank* tiktoken_corebpe_encode(CoreBPE* ptr, const char* text, const char* const* allowed_special,
+                              size_t allowed_special_len, size_t* num_tokens);
 
-Rank *tiktoken_corebpe_encode_with_special_tokens(CoreBPE *ptr,
-                                                  const char *text,
-                                                  size_t *num_tokens);
+Rank* tiktoken_corebpe_encode_with_special_tokens(CoreBPE* ptr, const char* text,
+                                                  size_t* num_tokens);
 
-char *tiktoken_corebpe_decode(CoreBPE *ptr, const Rank *tokens, size_t num_tokens);
-
-
+char* tiktoken_corebpe_decode(CoreBPE* ptr, const Rank* tokens, size_t num_tokens);

--- a/toml.c
+++ b/toml.c
@@ -2,7 +2,7 @@
  * Minimal TOML parser implementation for llm_ctx config loading
  * This is a simplified implementation that supports only the features we need:
  * - String values
- * - Boolean values  
+ * - Boolean values
  * - Integer values
  * - No nested tables, arrays, or other complex types
  */
@@ -19,144 +19,172 @@
 #define MAX_KEY 256
 #define MAX_VALUE 1024
 
-struct toml_table_t {
-    struct {
-        char *key;
-        char *value;
-    } *entries;
+struct toml_table_t
+{
+    struct
+    {
+        char* key;
+        char* value;
+    }* entries;
     int count;
     int capacity;
 };
 
-static void skip_whitespace(const char **p) {
-    while (**p && isspace(**p)) (*p)++;
+static void skip_whitespace(const char** p)
+{
+    while (**p && isspace(**p))
+        (*p)++;
 }
 
-static char *parse_string(const char *input, char *errbuf, int errbufsz) {
-    const char *p = input;
+static char* parse_string(const char* input, char* errbuf, int errbufsz)
+{
+    const char* p = input;
     skip_whitespace(&p);
-    
-    if (*p != '"') {
+
+    if (*p != '"')
+    {
         snprintf(errbuf, errbufsz, "Expected string to start with \"");
         return NULL;
     }
     p++; // skip opening quote
-    
-    const char *start = p;
-    while (*p && *p != '"') {
-        if (*p == '\\' && *(p+1)) {
+
+    const char* start = p;
+    while (*p && *p != '"')
+    {
+        if (*p == '\\' && *(p + 1))
+        {
             p += 2; // skip escape sequence
-        } else {
+        }
+        else
+        {
             p++;
         }
     }
-    
-    if (*p != '"') {
+
+    if (*p != '"')
+    {
         snprintf(errbuf, errbufsz, "Unterminated string");
         return NULL;
     }
-    
+
     size_t len = p - start;
-    char *result = malloc(len + 1);
-    if (!result) return NULL;
-    
+    char* result = malloc(len + 1);
+    if (!result)
+        return NULL;
+
     // Simple string copy without escape processing for now
     memcpy(result, start, len);
     result[len] = '\0';
-    
+
     return result;
 }
 
-toml_table_t *toml_parse_file(FILE *fp, char *errbuf, int errbufsz) {
-    toml_table_t *tab = calloc(1, sizeof(*tab));
-    if (!tab) {
+toml_table_t* toml_parse_file(FILE* fp, char* errbuf, int errbufsz)
+{
+    toml_table_t* tab = calloc(1, sizeof(*tab));
+    if (!tab)
+    {
         snprintf(errbuf, errbufsz, "Out of memory");
         return NULL;
     }
-    
+
     tab->capacity = 16;
     tab->entries = calloc(tab->capacity, sizeof(tab->entries[0]));
-    if (!tab->entries) {
+    if (!tab->entries)
+    {
         free(tab);
         snprintf(errbuf, errbufsz, "Out of memory");
         return NULL;
     }
-    
+
     char line[MAX_LINE];
     int line_no = 0;
-    
-    while (fgets(line, sizeof(line), fp)) {
+
+    while (fgets(line, sizeof(line), fp))
+    {
         line_no++;
-        
+
         // Remove newline
-        char *nl = strchr(line, '\n');
-        if (nl) *nl = '\0';
-        
+        char* nl = strchr(line, '\n');
+        if (nl)
+            *nl = '\0';
+
         // Skip empty lines and comments
-        const char *p = line;
+        const char* p = line;
         skip_whitespace(&p);
-        if (!*p || *p == '#') continue;
-        
+        if (!*p || *p == '#')
+            continue;
+
         // Find equals sign
-        char *eq = strchr(p, '=');
-        if (!eq) {
+        char* eq = strchr(p, '=');
+        if (!eq)
+        {
             snprintf(errbuf, errbufsz, "Line %d: No '=' found", line_no);
             toml_free(tab);
             return NULL;
         }
-        
+
         // Extract key
         char key[MAX_KEY];
         size_t key_len = eq - p;
-        if (key_len >= MAX_KEY) {
+        if (key_len >= MAX_KEY)
+        {
             snprintf(errbuf, errbufsz, "Line %d: Key too long", line_no);
             toml_free(tab);
             return NULL;
         }
         memcpy(key, p, key_len);
         key[key_len] = '\0';
-        
+
         // Trim key
-        char *key_end = key + key_len - 1;
-        while (key_end > key && isspace(*key_end)) key_end--;
+        char* key_end = key + key_len - 1;
+        while (key_end > key && isspace(*key_end))
+            key_end--;
         *(key_end + 1) = '\0';
-        
+
         // Parse value
         p = eq + 1;
         skip_whitespace(&p);
-        
+
         // Store key-value pair
-        if (tab->count >= tab->capacity) {
+        if (tab->count >= tab->capacity)
+        {
             // Expand capacity
             int new_capacity = tab->capacity * 2;
-            void *new_entries = realloc(tab->entries, new_capacity * sizeof(tab->entries[0]));
-            if (!new_entries) {
+            void* new_entries = realloc(tab->entries, new_capacity * sizeof(tab->entries[0]));
+            if (!new_entries)
+            {
                 snprintf(errbuf, errbufsz, "Out of memory");
                 toml_free(tab);
                 return NULL;
             }
             tab->entries = new_entries;
-            memset(&tab->entries[tab->capacity], 0, (new_capacity - tab->capacity) * sizeof(tab->entries[0]));
+            memset(&tab->entries[tab->capacity], 0,
+                   (new_capacity - tab->capacity) * sizeof(tab->entries[0]));
             tab->capacity = new_capacity;
         }
-        
+
         tab->entries[tab->count].key = strdup(key);
         tab->entries[tab->count].value = strdup(p);
-        if (!tab->entries[tab->count].key || !tab->entries[tab->count].value) {
+        if (!tab->entries[tab->count].key || !tab->entries[tab->count].value)
+        {
             snprintf(errbuf, errbufsz, "Out of memory");
             toml_free(tab);
             return NULL;
         }
         tab->count++;
     }
-    
+
     return tab;
 }
 
-void toml_free(toml_table_t *tab) {
-    if (!tab) return;
-    
-    for (int i = 0; i < tab->count; i++) {
+void toml_free(toml_table_t* tab)
+{
+    if (!tab)
+        return;
+
+    for (int i = 0; i < tab->count; i++)
+    {
         free(tab->entries[i].key);
         free(tab->entries[i].value);
     }
@@ -164,18 +192,23 @@ void toml_free(toml_table_t *tab) {
     free(tab);
 }
 
-toml_datum_t toml_string_in(const toml_table_t *tab, const char *key) {
+toml_datum_t toml_string_in(const toml_table_t* tab, const char* key)
+{
     toml_datum_t d = {0};
-    
-    for (int i = 0; i < tab->count; i++) {
-        if (strcmp(tab->entries[i].key, key) == 0) {
-            const char *val = tab->entries[i].value;
-            
+
+    for (int i = 0; i < tab->count; i++)
+    {
+        if (strcmp(tab->entries[i].key, key) == 0)
+        {
+            const char* val = tab->entries[i].value;
+
             // Check if it's a quoted string
-            if (*val == '"') {
+            if (*val == '"')
+            {
                 char errbuf[256];
-                char *str = parse_string(val, errbuf, sizeof(errbuf));
-                if (str) {
+                char* str = parse_string(val, errbuf, sizeof(errbuf));
+                if (str)
+                {
                     d.ok = 1;
                     d.u.s = str;
                 }
@@ -183,49 +216,59 @@ toml_datum_t toml_string_in(const toml_table_t *tab, const char *key) {
             return d;
         }
     }
-    
+
     return d;
 }
 
-toml_datum_t toml_bool_in(const toml_table_t *tab, const char *key) {
+toml_datum_t toml_bool_in(const toml_table_t* tab, const char* key)
+{
     toml_datum_t d = {0};
-    
-    for (int i = 0; i < tab->count; i++) {
-        if (strcmp(tab->entries[i].key, key) == 0) {
-            const char *val = tab->entries[i].value;
-            
-            if (strcmp(val, "true") == 0) {
+
+    for (int i = 0; i < tab->count; i++)
+    {
+        if (strcmp(tab->entries[i].key, key) == 0)
+        {
+            const char* val = tab->entries[i].value;
+
+            if (strcmp(val, "true") == 0)
+            {
                 d.ok = 1;
                 d.u.b = 1;
-            } else if (strcmp(val, "false") == 0) {
+            }
+            else if (strcmp(val, "false") == 0)
+            {
                 d.ok = 1;
                 d.u.b = 0;
             }
             return d;
         }
     }
-    
+
     return d;
 }
 
-toml_datum_t toml_int_in(const toml_table_t *tab, const char *key) {
+toml_datum_t toml_int_in(const toml_table_t* tab, const char* key)
+{
     toml_datum_t d = {0};
-    
-    for (int i = 0; i < tab->count; i++) {
-        if (strcmp(tab->entries[i].key, key) == 0) {
-            const char *val = tab->entries[i].value;
-            char *endptr;
-            
+
+    for (int i = 0; i < tab->count; i++)
+    {
+        if (strcmp(tab->entries[i].key, key) == 0)
+        {
+            const char* val = tab->entries[i].value;
+            char* endptr;
+
             errno = 0;
             long long num = strtoll(val, &endptr, 10);
-            
-            if (errno == 0 && *endptr == '\0' && num >= LLONG_MIN && num <= LLONG_MAX) {
+
+            if (errno == 0 && *endptr == '\0' && num >= LLONG_MIN && num <= LLONG_MAX)
+            {
                 d.ok = 1;
                 d.u.i = num;
             }
             return d;
         }
     }
-    
+
     return d;
 }

--- a/toml.h
+++ b/toml.h
@@ -29,97 +29,102 @@
 #include <stdio.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
-typedef struct toml_timestamp_t toml_timestamp_t;
-typedef struct toml_table_t toml_table_t;
-typedef struct toml_array_t toml_array_t;
-typedef struct toml_datum_t toml_datum_t;
+    typedef struct toml_timestamp_t toml_timestamp_t;
+    typedef struct toml_table_t toml_table_t;
+    typedef struct toml_array_t toml_array_t;
+    typedef struct toml_datum_t toml_datum_t;
 
-/* Parse a file. Return a table on success, or 0 otherwise. 
- * Caller must toml_free(the-return-value) after use.
- */
-toml_table_t *toml_parse_file(FILE *fp, char *errbuf, int errbufsz);
+    /* Parse a file. Return a table on success, or 0 otherwise.
+     * Caller must toml_free(the-return-value) after use.
+     */
+    toml_table_t* toml_parse_file(FILE* fp, char* errbuf, int errbufsz);
 
-/* Free the table returned by toml_parse_file() or toml_parse(). */
-void toml_free(toml_table_t *tab);
+    /* Free the table returned by toml_parse_file() or toml_parse(). */
+    void toml_free(toml_table_t* tab);
 
-/* Timestamp types. The year, month, day, hour, minute, second, z 
- * fields may be NULL if they are not relevant.
- */
-struct toml_timestamp_t {
-    struct { /* internal. do not use. */
-        int year, month, day;
-        int hour, minute, second, millisec;
-        char z[10];
-    } __buffer;
-    int *year, *month, *day;
-    int *hour, *minute, *second, *millisec;
-    char *z;
-};
+    /* Timestamp types. The year, month, day, hour, minute, second, z
+     * fields may be NULL if they are not relevant.
+     */
+    struct toml_timestamp_t
+    {
+        struct
+        { /* internal. do not use. */
+            int year, month, day;
+            int hour, minute, second, millisec;
+            char z[10];
+        } __buffer;
+        int *year, *month, *day;
+        int *hour, *minute, *second, *millisec;
+        char* z;
+    };
 
-/* Enhanced access methods */
-struct toml_datum_t {
-    int ok;
-    union {
-        toml_timestamp_t *ts; /* ts must be freed after use */
-        char *s;              /* string value. s must be freed after use */
-        int b;                /* bool value */
-        int64_t i;            /* int value */
-        double d;             /* double value */
-    } u;
-};
+    /* Enhanced access methods */
+    struct toml_datum_t
+    {
+        int ok;
+        union
+        {
+            toml_timestamp_t* ts; /* ts must be freed after use */
+            char* s;              /* string value. s must be freed after use */
+            int b;                /* bool value */
+            int64_t i;            /* int value */
+            double d;             /* double value */
+        } u;
+    };
 
-/* on arrays: */
-/* ... retrieve size of array. */
-int toml_array_nelem(const toml_array_t *arr);
-/* ... retrieve values using index. */
-toml_datum_t toml_string_at(const toml_array_t *arr, int idx);
-toml_datum_t toml_bool_at(const toml_array_t *arr, int idx);
-toml_datum_t toml_int_at(const toml_array_t *arr, int idx);
-toml_datum_t toml_double_at(const toml_array_t *arr, int idx);
-toml_datum_t toml_timestamp_at(const toml_array_t *arr, int idx);
-/* ... retrieve array or table using index. */
-toml_array_t *toml_array_at(const toml_array_t *arr, int idx);
-toml_table_t *toml_table_at(const toml_array_t *arr, int idx);
+    /* on arrays: */
+    /* ... retrieve size of array. */
+    int toml_array_nelem(const toml_array_t* arr);
+    /* ... retrieve values using index. */
+    toml_datum_t toml_string_at(const toml_array_t* arr, int idx);
+    toml_datum_t toml_bool_at(const toml_array_t* arr, int idx);
+    toml_datum_t toml_int_at(const toml_array_t* arr, int idx);
+    toml_datum_t toml_double_at(const toml_array_t* arr, int idx);
+    toml_datum_t toml_timestamp_at(const toml_array_t* arr, int idx);
+    /* ... retrieve array or table using index. */
+    toml_array_t* toml_array_at(const toml_array_t* arr, int idx);
+    toml_table_t* toml_table_at(const toml_array_t* arr, int idx);
 
-/* on tables: */
-/* ... retrieve value using key. */
-toml_datum_t toml_string_in(const toml_table_t *arr, const char *key);
-toml_datum_t toml_bool_in(const toml_table_t *arr, const char *key);
-toml_datum_t toml_int_in(const toml_table_t *arr, const char *key);
-toml_datum_t toml_double_in(const toml_table_t *arr, const char *key);
-toml_datum_t toml_timestamp_in(const toml_table_t *arr, const char *key);
-/* ... retrieve array or table using key. */
-toml_array_t *toml_array_in(const toml_table_t *tab, const char *key);
-toml_table_t *toml_table_in(const toml_table_t *tab, const char *key);
+    /* on tables: */
+    /* ... retrieve value using key. */
+    toml_datum_t toml_string_in(const toml_table_t* arr, const char* key);
+    toml_datum_t toml_bool_in(const toml_table_t* arr, const char* key);
+    toml_datum_t toml_int_in(const toml_table_t* arr, const char* key);
+    toml_datum_t toml_double_in(const toml_table_t* arr, const char* key);
+    toml_datum_t toml_timestamp_in(const toml_table_t* arr, const char* key);
+    /* ... retrieve array or table using key. */
+    toml_array_t* toml_array_in(const toml_table_t* tab, const char* key);
+    toml_table_t* toml_table_in(const toml_table_t* tab, const char* key);
 
-/*
- * Process raw string and int.
- * DEPRECATED: The use of these functions is discouraged.
- */
-int toml_rtos(char *s, char **ret);
-int toml_rtoi(const char *s, int64_t *ret);
+    /*
+     * Process raw string and int.
+     * DEPRECATED: The use of these functions is discouraged.
+     */
+    int toml_rtos(char* s, char** ret);
+    int toml_rtoi(const char* s, int64_t* ret);
 
-/*
- * Misc
- */
-int toml_key_exists(const toml_table_t *tab, const char *key);
-int toml_key_in(const toml_table_t *tab, const char *key);
-/* ... retrieve the key in table at keyidx. Return 0 if out of range. */
-const char *toml_key_in_table(const toml_table_t *tab, int keyidx);
-/* ... retrieve number of keys in table. */
-int toml_table_nkval(const toml_table_t *tab);
-/* ... retrieve number of arrays in table. */
-int toml_table_narr(const toml_table_t *tab);
-/* ... retrieve number of sub-tables in table. */
-int toml_table_ntab(const toml_table_t *tab);
-/* ... retrieve table in table at tabidx. Return 0 if out of range. */
-toml_table_t *toml_table_table(const toml_table_t *tab, int tabidx);
+    /*
+     * Misc
+     */
+    int toml_key_exists(const toml_table_t* tab, const char* key);
+    int toml_key_in(const toml_table_t* tab, const char* key);
+    /* ... retrieve the key in table at keyidx. Return 0 if out of range. */
+    const char* toml_key_in_table(const toml_table_t* tab, int keyidx);
+    /* ... retrieve number of keys in table. */
+    int toml_table_nkval(const toml_table_t* tab);
+    /* ... retrieve number of arrays in table. */
+    int toml_table_narr(const toml_table_t* tab);
+    /* ... retrieve number of sub-tables in table. */
+    int toml_table_ntab(const toml_table_t* tab);
+    /* ... retrieve table in table at tabidx. Return 0 if out of range. */
+    toml_table_t* toml_table_table(const toml_table_t* tab, int tabidx);
 
-/* misc */
-void toml_set_memutil(void *(*xxmalloc)(size_t), void (*xxfree)(void *));
+    /* misc */
+    void toml_set_memutil(void* (*xxmalloc)(size_t), void (*xxfree)(void*));
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- add a repository-wide .clang-format configuration that encodes the preferred style
- reformat the primary sources and headers to match the new baseline
- provide a make format target and documentation so contributors can easily re-run the formatter

## Testing
- make format

------
https://chatgpt.com/codex/tasks/task_e_68ee487eaea8832b92a7d383035aa2dd