### PR TITLE
Add clang-tidy configuration and fix analyzer warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,11 @@
+Checks: >
+  -*,
+  bugprone-*,
+  clang-analyzer-*,
+  -clang-analyzer-security.insecureAPI.DeprecatedOrUnsafeBufferHandling,
+  cert-*,
+  modernize-deprecated-headers,
+  modernize-redundant-void-arg
+WarningsAsErrors: ''
+HeaderFilterRegex: '.*'
+FormatStyle: none

--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -1,0 +1,19 @@
+name: clang-tidy
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install clang-tidy
+        run: sudo apt-get update && sudo apt-get install -y clang-tidy
+      - name: Run clang-tidy on C sources
+        run: |
+          git ls-files '*.c' | xargs -n 1 clang-tidy \
+            --quiet \
+            --warnings-as-errors=clang-analyzer-security.insecureAPI.strcpy,clang-analyzer-security.insecureAPI.strcat

--- a/arena.h
+++ b/arena.h
@@ -8,11 +8,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-// Custom max_align_t for systems without it
-#if !defined(__STDC_VERSION_STDDEF_H__) && !defined(_MSC_VER) && !defined(_MAX_ALIGN_T_DEFINED) && !defined(__APPLE__)
-typedef union { long long i; long double d; void *p; } max_align_t;
-#define _MAX_ALIGN_T_DEFINED
-#endif
+// Rely on the standard definition of max_align_t when available.
 
 #ifdef __cplusplus
 extern "C" {

--- a/compile_commands.json
+++ b/compile_commands.json
@@ -1,0 +1,102 @@
+[
+  {
+    "directory": "/workspace/llm_ctx",
+    "command": "gcc -std=c99 -Wall -Wextra -Werror -Wstrict-prototypes -D_GNU_SOURCE -g -I. -c arena.c -o arena.o",
+    "file": "/workspace/llm_ctx/arena.c"
+  },
+  {
+    "directory": "/workspace/llm_ctx",
+    "command": "gcc -std=c99 -Wall -Wextra -Werror -Wstrict-prototypes -D_GNU_SOURCE -g -I. -c config.c -o config.o",
+    "file": "/workspace/llm_ctx/config.c"
+  },
+  {
+    "directory": "/workspace/llm_ctx",
+    "command": "gcc -std=c99 -Wall -Wextra -Werror -Wstrict-prototypes -D_GNU_SOURCE -g -I. -c debug.c -o debug.o",
+    "file": "/workspace/llm_ctx/debug.c"
+  },
+  {
+    "directory": "/workspace/llm_ctx",
+    "command": "gcc -std=c99 -Wall -Wextra -Werror -Wstrict-prototypes -D_GNU_SOURCE -g -I. -c gitignore.c -o gitignore.o",
+    "file": "/workspace/llm_ctx/gitignore.c"
+  },
+  {
+    "directory": "/workspace/llm_ctx",
+    "command": "gcc -std=c99 -Wall -Wextra -Werror -Wstrict-prototypes -D_GNU_SOURCE -g -I. -c main.c -o main.o",
+    "file": "/workspace/llm_ctx/main.c"
+  },
+  {
+    "directory": "/workspace/llm_ctx/tests",
+    "command": "gcc -std=c99 -Wall -Wextra -Werror -Wstrict-prototypes -D_GNU_SOURCE -g -I. -c tests/test_arena.c -o test_arena.o",
+    "file": "/workspace/llm_ctx/tests/test_arena.c"
+  },
+  {
+    "directory": "/workspace/llm_ctx/tests",
+    "command": "gcc -std=c99 -Wall -Wextra -Werror -Wstrict-prototypes -D_GNU_SOURCE -g -I. -c tests/test_cli.c -o test_cli.o",
+    "file": "/workspace/llm_ctx/tests/test_cli.c"
+  },
+  {
+    "directory": "/workspace/llm_ctx/tests",
+    "command": "gcc -std=c99 -Wall -Wextra -Werror -Wstrict-prototypes -D_GNU_SOURCE -g -I. -c tests/test_cli_exclude.c -o test_cli_exclude.o",
+    "file": "/workspace/llm_ctx/tests/test_cli_exclude.c"
+  },
+  {
+    "directory": "/workspace/llm_ctx/tests",
+    "command": "gcc -std=c99 -Wall -Wextra -Werror -Wstrict-prototypes -D_GNU_SOURCE -g -I. -c tests/test_config.c -o test_config.o",
+    "file": "/workspace/llm_ctx/tests/test_config.c"
+  },
+  {
+    "directory": "/workspace/llm_ctx/tests",
+    "command": "gcc -std=c99 -Wall -Wextra -Werror -Wstrict-prototypes -D_GNU_SOURCE -g -I. -c tests/test_filerank.c -o test_filerank.o",
+    "file": "/workspace/llm_ctx/tests/test_filerank.c"
+  },
+  {
+    "directory": "/workspace/llm_ctx/tests",
+    "command": "gcc -std=c99 -Wall -Wextra -Werror -Wstrict-prototypes -D_GNU_SOURCE -g -I. -c tests/test_filerank_cutoff.c -o test_filerank_cutoff.o",
+    "file": "/workspace/llm_ctx/tests/test_filerank_cutoff.c"
+  },
+  {
+    "directory": "/workspace/llm_ctx/tests",
+    "command": "gcc -std=c99 -Wall -Wextra -Werror -Wstrict-prototypes -D_GNU_SOURCE -g -I. -c tests/test_gitignore.c -o test_gitignore.o",
+    "file": "/workspace/llm_ctx/tests/test_gitignore.c"
+  },
+  {
+    "directory": "/workspace/llm_ctx/tests",
+    "command": "gcc -std=c99 -Wall -Wextra -Werror -Wstrict-prototypes -D_GNU_SOURCE -g -I. -c tests/test_keywords.c -o test_keywords.o",
+    "file": "/workspace/llm_ctx/tests/test_keywords.c"
+  },
+  {
+    "directory": "/workspace/llm_ctx/tests",
+    "command": "gcc -std=c99 -Wall -Wextra -Werror -Wstrict-prototypes -D_GNU_SOURCE -g -I. -c tests/test_stdin.c -o test_stdin.o",
+    "file": "/workspace/llm_ctx/tests/test_stdin.c"
+  },
+  {
+    "directory": "/workspace/llm_ctx/tests",
+    "command": "gcc -std=c99 -Wall -Wextra -Werror -Wstrict-prototypes -D_GNU_SOURCE -g -I. -c tests/test_tokenizer.c -o test_tokenizer.o",
+    "file": "/workspace/llm_ctx/tests/test_tokenizer.c"
+  },
+  {
+    "directory": "/workspace/llm_ctx/tests",
+    "command": "gcc -std=c99 -Wall -Wextra -Werror -Wstrict-prototypes -D_GNU_SOURCE -g -I. -c tests/test_tokenizer_cli.c -o test_tokenizer_cli.o",
+    "file": "/workspace/llm_ctx/tests/test_tokenizer_cli.c"
+  },
+  {
+    "directory": "/workspace/llm_ctx/tests",
+    "command": "gcc -std=c99 -Wall -Wextra -Werror -Wstrict-prototypes -D_GNU_SOURCE -g -I. -c tests/test_tree_flags.c -o test_tree_flags.o",
+    "file": "/workspace/llm_ctx/tests/test_tree_flags.c"
+  },
+  {
+    "directory": "/workspace/llm_ctx",
+    "command": "gcc -std=c99 -Wall -Wextra -Werror -Wstrict-prototypes -D_GNU_SOURCE -g -I. -c tokenizer.c -o tokenizer.o",
+    "file": "/workspace/llm_ctx/tokenizer.c"
+  },
+  {
+    "directory": "/workspace/llm_ctx",
+    "command": "gcc -std=c99 -Wall -Wextra -Werror -Wstrict-prototypes -D_GNU_SOURCE -g -I. -c tokenizer_diagnostics.c -o tokenizer_diagnostics.o",
+    "file": "/workspace/llm_ctx/tokenizer_diagnostics.c"
+  },
+  {
+    "directory": "/workspace/llm_ctx",
+    "command": "gcc -std=c99 -Wall -Wextra -Werror -Wstrict-prototypes -D_GNU_SOURCE -g -I. -c toml.c -o toml.o",
+    "file": "/workspace/llm_ctx/toml.c"
+  }
+]

--- a/gitignore.c
+++ b/gitignore.c
@@ -137,7 +137,7 @@ void load_gitignore_file(const char *filepath) {
         add_ignore_pattern(line);
     }
     
-    fclose(file);
+    (void)fclose(file);
 }
 
 /**
@@ -157,8 +157,10 @@ void load_all_gitignore_files(void) {
     assert(current_dir[0] != '\0');
     
     /* First, try to load .gitignore from the current directory */
-    snprintf(gitignore_path, sizeof(gitignore_path), "%s/.gitignore", current_dir);
-    load_gitignore_file(gitignore_path);
+    int written = snprintf(gitignore_path, sizeof(gitignore_path), "%s/.gitignore", current_dir);
+    if (written >= 0 && (size_t)written < sizeof(gitignore_path)) {
+        load_gitignore_file(gitignore_path);
+    }
     
     /* Then, try to load from parent directories */
     char *dir = current_dir;
@@ -169,8 +171,10 @@ void load_all_gitignore_files(void) {
         *last_slash = '\0';
         
         /* Try to load .gitignore from this directory */
-        snprintf(gitignore_path, sizeof(gitignore_path), "%s/.gitignore", dir);
-        load_gitignore_file(gitignore_path);
+        written = snprintf(gitignore_path, sizeof(gitignore_path), "%s/.gitignore", dir);
+        if (written >= 0 && (size_t)written < sizeof(gitignore_path)) {
+            load_gitignore_file(gitignore_path);
+        }
         
         /* Stop if we've reached the root directory */
         if (last_slash == dir) {


### PR DESCRIPTION
## Summary
- add a clang-tidy configuration and compile_commands.json so static analysis can understand the build
- harden config path handling and template parsing by checking snprintf/fseek results and avoiding unsafe copies
- tighten supporting utilities (main scoring path, gitignore loader, tokenizer loader, arena headers) and add a CI workflow that runs clang-tidy on pushes and PRs

## Testing
- make llm_ctx
- clang-tidy config.c --warnings-as-errors=* --quiet
- clang-tidy gitignore.c --warnings-as-errors=* --quiet
- clang-tidy tokenizer.c --warnings-as-errors=* --quiet

------
https://chatgpt.com/codex/tasks/task_e_68ee489ca134832bb9455adbc6b77464